### PR TITLE
Sanitize user input

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -53,6 +53,7 @@ class Renderer
 
             if ($renderClass->matching()) {
                 $html[] = $this->renderOpeningTag($renderClass->tag());
+                break;
             }
         }
 

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -61,7 +61,7 @@ class Renderer
                 $html[] = $this->renderNode($nestedNode);
             }
         } elseif (isset($node->text)) {
-            $html[] = $node->text;
+            $html[] = htmlentities($node->text, ENT_QUOTES);
         } elseif ($text = $renderClass->text()) {
             $html[] = $text;
         }

--- a/tests/Nodes/XSSTest.php
+++ b/tests/Nodes/XSSTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Scrumpy\ProseMirrorToHtml\Test\Nodes;
+
+
+use Scrumpy\ProseMirrorToHtml\Renderer;
+use Scrumpy\ProseMirrorToHtml\Test\TestCase;
+
+class XSSTest extends TestCase
+{
+
+    /** @test */
+    public function text_should_not_get_rendered_as_html()
+    {
+        $json = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => '<script>alert(1)</script>',
+                ],
+            ],
+        ];
+
+        $renderer = new Renderer();
+        $html = $renderer->render($json);
+
+        // assert that the input has been sanitized
+        $this->assertEquals('&lt;script&gt;alert(1)&lt;/script&gt;', $html);
+    }
+}


### PR DESCRIPTION
This PR sanitizes the text fields of a node. 

Also adds a break statement in the foreach over the available nodes. So the correct `$renderClass->text()` is called.