### PR TITLE
Fix node with no text using the text method from a custom node

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -62,7 +62,7 @@ class Renderer
             }
         } elseif (isset($node->text)) {
             $html[] = $node->text;
-        } elseif ($text = $renderClass->text()) {
+        } elseif ($renderClass->matching() && ($text = $renderClass->text())) {
             $html[] = $text;
         }
 

--- a/tests/Nodes/CustomNodeTest.php
+++ b/tests/Nodes/CustomNodeTest.php
@@ -69,4 +69,24 @@ class CustomNodeTest extends TestCase
 
         $this->assertEquals($html, $renderer->render($json));
     }
+
+    /** @test */
+    public function a_custom_nodes_text_does_not_get_used_when_other_nodes_dont_have_text()
+    {
+        $json = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                ],
+            ],
+        ];
+
+        $html = '<p></p>';
+
+        $renderer = new Renderer;
+        $renderer->addNode(Custom\User::class);
+
+        $this->assertEquals($html, $renderer->render($json));
+    }
 }


### PR DESCRIPTION
When you have a paragraph with no text, ProseMirror saves it like this:

``` php
'content' => [
    [
        'type' => 'paragraph',
        // there's no 'text' key here
    ],
],
```

Combine that, with a custom node that has a `text()` method, and the paragraph would use the custom node's text.

This is because the loop on lines 51-56 goes through all the nodes and `$renderClass` will always be the last registered class, even when a different class matched.

I had a hard time trying to write a test that covers `break`-ing out of the loop, so instead, adding another `->matching()` check also fixes it.
