### PR TITLE
Add support for handling single or unpaired tags

### DIFF
--- a/src/Nodes/Node.php
+++ b/src/Nodes/Node.php
@@ -16,9 +16,9 @@ class Node
         return false;
     }
 
-    public function paired()
+    public function selfClosing()
     {
-        return true;
+        return false;
     }
 
     public function tag()

--- a/src/Nodes/Node.php
+++ b/src/Nodes/Node.php
@@ -16,6 +16,11 @@ class Node
         return false;
     }
 
+    public function paired()
+    {
+        return true;
+    }
+
     public function tag()
     {
         return null;

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -70,7 +70,9 @@ class Renderer
         foreach ($this->nodes as $class) {
             $renderClass = new $class($node);
 
-            if ($renderClass->matching() && $renderClass->paired()) {
+            if ($renderClass->selfClosing()) continue;
+
+            if ($renderClass->matching()) {
                 $html[] = $this->renderClosingTag($renderClass->tag());
             }
         }

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -70,7 +70,7 @@ class Renderer
         foreach ($this->nodes as $class) {
             $renderClass = new $class($node);
 
-            if ($renderClass->matching()) {
+            if ($renderClass->matching() && $renderClass->paired()) {
                 $html[] = $this->renderClosingTag($renderClass->tag());
             }
         }

--- a/tests/Nodes/Custom/HardBreak.php
+++ b/tests/Nodes/Custom/HardBreak.php
@@ -11,9 +11,9 @@ class HardBreak extends Node
         return $this->node->type === 'hard_break';
     }
 
-    public function paired()
+    public function selfClosing()
     {
-        return false;
+        return true;
     }
 
     public function tag()

--- a/tests/Nodes/Custom/HardBreak.php
+++ b/tests/Nodes/Custom/HardBreak.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Scrumpy\ProseMirrorToHtml\Test\Nodes\Custom;
+
+use Scrumpy\ProseMirrorToHtml\Nodes\Node;
+
+class HardBreak extends Node
+{
+    public function matching()
+    {
+        return $this->node->type === 'hard_break';
+    }
+
+    public function paired()
+    {
+        return false;
+    }
+
+    public function tag()
+    {
+        return 'br';
+    }
+}

--- a/tests/Nodes/UnpairedNodeTest.php
+++ b/tests/Nodes/UnpairedNodeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Scrumpy\ProseMirrorToHtml\Test\Nodes;
+
+use Scrumpy\ProseMirrorToHtml\Renderer;
+use Scrumpy\ProseMirrorToHtml\Test\TestCase;
+use Scrumpy\ProseMirrorToHtml\Test\Nodes\Custom\HardBreak;
+
+class UnpairedNodeTest extends TestCase
+{
+    /** @test */
+    public function an_unpaired_node_gets_rendered_correctly()
+    {
+        $json = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'some text',
+                        ],
+                        [
+                            'type' => 'hard_break'
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => 'some more text'
+                        ]
+                    ],
+                ],
+            ],
+        ];
+
+        $html = '<p>some text<br>some more text</p>';
+
+        $renderer = new Renderer;
+        $renderer->addNode(HardBreak::class);
+
+        $this->assertEquals($html, $renderer->render($json));
+    }
+}


### PR DESCRIPTION
At present, when trying to implement a custom node that does not require a closing tag, such as a br or img, you will end up with HTML output such as:

`<img></img> `
or 
`<br></br>`

This change allows for flagging a node as being unpaired in order to handle this scenario, while maintaining the default behaviour of assuming a node as being paired to avoid introducing a breaking change.