### PR TITLE
add HardBreak node

### DIFF
--- a/src/Nodes/HardBreak.php
+++ b/src/Nodes/HardBreak.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Scrumpy\ProseMirrorToHtml\Nodes;
+
+class HardBreak extends Node
+{
+    public function matching()
+    {
+        return $this->node->type === 'hard_break';
+    }
+
+    public function selfClosing()
+    {
+        return true;
+    }
+
+    public function tag()
+    {
+        return 'br';
+    }
+}

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -10,6 +10,7 @@ class Renderer
         Nodes\Blockquote::class,
         Nodes\BulletList::class,
         Nodes\CodeBlock::class,
+        Nodes\HardBreak::class,
         Nodes\Heading::class,
         Nodes\ListItem::class,
         Nodes\OrderedList::class,


### PR DESCRIPTION
This PR adds a Node class to render ProseMirror's `hard_break` node.