### PR TITLE
Add Strike mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ composer require scrumpy/prosemirror-to-html
 - Code
 - Italic
 - Link
+- Strike
+- Underline
 
 ## Custom Nodes
 

--- a/src/Marks/Strike.php
+++ b/src/Marks/Strike.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Scrumpy\ProseMirrorToHtml\Marks;
+
+class Strike extends Mark
+{
+    public function matching()
+    {
+        return $this->mark->type === 'strike';
+    }
+
+    public function tag()
+    {
+        return 'strike';
+    }
+}


### PR DESCRIPTION
This is to help the package support all the marks TipTap does. This also updates the README to reflect the Marks list.